### PR TITLE
Simplify webpack config

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -4,7 +4,7 @@
   "description": "ng-redux counter example",
   "main": "index.js",
   "scripts": {
-    "start": "webpack && webpack-dev-server --content-base dist/ --hot"
+    "start": "webpack-dev-server --content-base dist/ --inline"
   },
   "repository": {
     "type": "git",

--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -4,7 +4,6 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   entry: [
-    'webpack/hot/dev-server',
     './index.js',
     //Remove the following line to remove devTools
     './devTools.js'
@@ -19,17 +18,20 @@ module.exports = {
       template: './index.html',
       inject: 'body'
     }),
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
-  resolve: {
-    extensions: ['', '.ts', '.webpack.js', '.web.js', '.js']
-  },
   devtool: 'source-map',
   module: {
     loaders: [
-     {test: /\.js$/, exclude: /node_modules/, loader: "babel-loader"},
-     { test: /\.html$/, loader: 'html' }
-     ]
+      {
+        test: /\.js$/,
+        loader: "babel",
+        exclude: /node_modules/
+      },
+      {
+        test: /\.html$/,
+        loader: 'html'
+      }
+    ]
   }
 };


### PR DESCRIPTION
This simplifies the webpack by removing all the react stuff only. Also structured the bottom code a bit better.

Also I removed the `webpack` execution from the `package.json` because that delays the server execution and will create the `dist` folder without need.