### PR TITLE
Change vm for something else

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ class CounterController {
 
 ```HTML
 <div>
-    <p>Clicked: {{vm.counter}} times </p>
-    <button ng-click='vm.increment()'>+</button>
-    <button ng-click='vm.decrement()'>-</button>
-    <button ng-click='vm.incrementIfOdd()'>Increment if odd</button>
-    <button ng-click='vm.incrementAsync()'>Increment Async</button>
+    <p>Clicked: {{counter.value}} times </p>
+    <button ng-click='counter.increment()'>+</button>
+    <button ng-click='counter.decrement()'>-</button>
+    <button ng-click='counter.incrementIfOdd()'>Increment if odd</button>
+    <button ng-click='counter.incrementAsync()'>Increment Async</button>
 </div>
 ```
 

--- a/examples/counter/components/counter.html
+++ b/examples/counter/components/counter.html
@@ -1,8 +1,8 @@
 <div>
-    <p>Clicked: {{vm.counter}} times </p>
+    <p>Clicked: {{counter.value}} times </p>
 
-    <button ng-click='vm.increment()'>+</button>
-    <button ng-click='vm.decrement()'>-</button>
-    <button ng-click='vm.incrementIfOdd()'>Increment if odd</button>
-    <button ng-click='vm.incrementAsync()'>Increment Async</button>
+    <button ng-click='counter.increment()'>+</button>
+    <button ng-click='counter.decrement()'>-</button>
+    <button ng-click='counter.incrementIfOdd()'>Increment if odd</button>
+    <button ng-click='counter.incrementAsync()'>Increment Async</button>
 </div>

--- a/examples/counter/components/counter.js
+++ b/examples/counter/components/counter.js
@@ -3,7 +3,7 @@ import * as CounterActions from '../actions/counter';
 export default function counter() {
   return {
     restrict: 'E',
-    controllerAs: 'vm',
+    controllerAs: 'counter',
     controller: CounterController,
     template: require('./counter.html'),
     scope: {}
@@ -20,7 +20,7 @@ class CounterController {
   // Which part of the Redux global state does our component want to receive on $scope?
   mapStateToScope(state) {
     return {
-      counter: state.counter
+      value: state.counter
     };
   }
 }


### PR DESCRIPTION
`vm` is very bad choice to name a `controllerAs`. I know that people uses it, but we saw that it was not that good because it defeats half of the purpose (being able to identify from where the variable comes from).

This new name makes the template much much easier to read.