### PR TITLE
Pass custom combine reducers function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Add the following script tag to your html:
 
 #### Initialization
 
+You can initialize ngRedux two ways:
+
+Function as the reducer argument for the `createStoreWith`:
+
 ```JS
 import reducers from './reducers';
 import { combineReducers } from 'redux';
@@ -53,6 +57,27 @@ angular.module('app', [ngRedux])
     $ngReduxProvider.createStoreWith(reducer, ['promiseMiddleware', loggingMiddleware]);
   });
 ```
+
+A reducer object as reducer argument for the `createStoreWith`:
+
+```JS
+import reducers from './reducers';
+import { combineReducers } from 'redux';
+import loggingMiddleware from './loggingMiddleware';
+import ngRedux from 'ng-redux';
+
+angular.module('app', [ngRedux])
+.config(($ngReduxProvider) => {
+	reducer3 = functtion(state, action){}
+    $ngReduxProvider.createStoreWith({
+		reducer1: "reducer1",
+		reducer2: function(state, action){},
+		reducer3: reducer3
+	 }, ['promiseMiddleware', loggingMiddleware]);
+  });
+```
+
+The object can be constructed either by passing a function as value or a string representing the reducer. This way, you can create reducers as services and initialze them inside the `.config`. Behind the secnes, ngRedux will `$injector.get` the string you pass as the value for the ojects of reducers and initilaze it.
 
 #### Usage
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ angular.module('app', [ngRedux])
 
 The object can be constructed either by passing a function as value or a string representing the reducer. This way, you can create reducers as services and initialze them inside the `.config`. Behind the secnes, ngRedux will `$injector.get` the string you pass as the value for the ojects of reducers and initilaze it.
 
+You can also pass custom `combineReducers` to `$ngReduxProvider`, which is extremely helpfull if you want to use libraries such as [redux-immutable](https://github.com/gajus/redux-immutable) for example.
+
+```JS
+import reducers from './reducers';
+import myCombineReducers from 'redux-immutable';
+import loggingMiddleware from './loggingMiddleware';
+import ngRedux from 'ng-redux';
+
+angular.module('app', [ngRedux])
+.config(($ngReduxProvider) => {
+	$ngReduxProvider.combineReducersFunc(myCombineReducers);
+	reducer3 = functtion(state, action){}
+	$ngReduxProvider.createStoreWith({
+		reducer1: "reducer1",
+		reducer2: function(state, action){},
+		reducer3: reducer3
+	 }, ['promiseMiddleware', loggingMiddleware]);
+  });
+```
+
+By passing `$ngReduxProvider.combineReducersFunc(myCombineReducers);`, ngRedux will use the new myCombineReducers function instead of the default one that comes with redux.
+
 #### Usage
 
 *Using controllerAs syntax*

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -14,6 +14,17 @@ export default function ngReduxProvider() {
   let _storeEnhancers = undefined;
   let _initialState = undefined;
   let _reducerIsObject = undefined;
+  let _combineReducers = undefined;
+
+  this.combineReducersFunc = (func) => {
+    invariant(
+      isFunction(reducer),
+      'The parameter passed to combineReducersFunc must be a Function. Instead received %s.',
+      typeof reducer
+    );
+
+    _combineReducers = func;
+  };
 
   this.createStoreWith = (reducer, middlewares, storeEnhancers, initialState) => {
     invariant(
@@ -37,6 +48,7 @@ export default function ngReduxProvider() {
 
   this.$get = ($injector) => {
     let store, resolvedMiddleware = [];
+    let finalCombineReducers = _combineReducers ? _combineReducers : combineReducers;
 
     for(let middleware of _middlewares) {
       if(typeof middleware === 'string') {
@@ -58,7 +70,7 @@ export default function ngReduxProvider() {
         }  
       });
 
-      _reducer = combineReducers(reducersObj);
+      _reducer = finalCombineReducers(reducersObj);
     }
 
     let finalCreateStore = _storeEnhancers ? compose(..._storeEnhancers)(createStore) : createStore;

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -6,18 +6,18 @@ import digestMiddleware from './digestMiddleware';
 import assign from 'lodash.assign';
 import isArray from 'lodash.isarray';
 import isFunction from 'lodash.isfunction';
-import isObejct from 'lodash.isobject';
+import isObject from 'lodash.isobject';
 
 export default function ngReduxProvider() {
   let _reducer = undefined;
   let _middlewares = undefined;
   let _storeEnhancers = undefined;
   let _initialState = undefined;
-  let _reducerIsObejct = undefined;
+  let _reducerIsObject = undefined;
 
   this.createStoreWith = (reducer, middlewares, storeEnhancers, initialState) => {
     invariant(
-      isFunction(reducer) || isObejct(reducer),
+      isFunction(reducer) || isObject(reducer),
       'The reducer parameter passed to createStoreWith must be a Function or an Object. Instead received %s.',
       typeof reducer
     );
@@ -29,7 +29,7 @@ export default function ngReduxProvider() {
     );
 
     _reducer = reducer;
-    _reducerIsObejct = isObejct(reducer);
+    _reducerIsObject = isObject(reducer);
     _storeEnhancers = storeEnhancers
     _middlewares = middlewares || [];
     _initialState = initialState;
@@ -46,7 +46,7 @@ export default function ngReduxProvider() {
       }
     }
 
-    if(_reducerIsObejct) {
+    if(_reducerIsObject) {
       let reducersObj = {};
       let reducKeys = Object.keys(_reducer); 
 


### PR DESCRIPTION
Hi,

This PR aims to add custom combineReducers function to the `$ngReduxProvider`, which is extremely helpfull if you want to use libraries such as [redux-immutable](https://github.com/gajus/redux-immutable) for example.

```JS
import reducers from './reducers';
import myCombineReducers from 'redux-immutable';
import loggingMiddleware from './loggingMiddleware';
import ngRedux from 'ng-redux';

angular.module('app', [ngRedux])
.config(($ngReduxProvider) => {
	$ngReduxProvider.combineReducersFunc(myCombineReducers);
	reducer3 = functtion(state, action){}
	$ngReduxProvider.createStoreWith({
		reducer1: "reducer1",
		reducer2: function(state, action){},
		reducer3: reducer3
	 }, ['promiseMiddleware', loggingMiddleware]);
  });
```

By passing `$ngReduxProvider.combineReducersFunc(myCombineReducers);`, ngRedux will use the new myCombineReducers function instead of the default one that comes with redux.

This PR starts from this other PR https://github.com/wbuchwalter/ng-redux/pull/76

Let me know what you think.
Thanks